### PR TITLE
stategy for testing rdf outout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target
 # however the content changes even if the code did not
 src/test/resources/cars/out
 /.flattened-pom.xml
+DCAT-AP/

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target
 src/test/resources/cars/out
 /.flattened-pom.xml
 DCAT-AP/
+.tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ target
 # I see no harm in exposing the test output
 # however the content changes even if the code did not
 src/test/resources/cars/out
+src/test/resources/cars/validation_output.ttl
+src/test/resources/cars/shacl-results.csv
 /.flattened-pom.xml
 DCAT-AP/
 .tmp/

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 DCAT-AP Exporter for Dataverse
 ==============================
 
-This exporter is based on the DCAT-AP specification for describing datasets in a standardized way. 
-It allows users to export metadata from Dataverse Datasets into aDCAT-AP compliant format.
+This exporter is based on the [DCAT-AP](https://semiceu.github.io/DCAT-AP/releases/3.0.0/) 3.0.0 specification for describing datasets in a standardized way. 
+It allows users to export metadata from Dataverse Datasets into a DCAT-AP compliant format.
 
 > [!WARNING]
 > This exporter is a work in progress and may not yet fully comply with the DCAT-AP specification.
@@ -15,3 +15,13 @@ Dataverse must be configured to load extra exporters from this directory.
 See the Dataverse documentation for more details:
 https://guides.dataverse.org/en/latest/installation/config.html#dataverse-spi-exporters-directory
 
+
+# Testing
+
+## Exporter Output
+
+In order to test compliance of the exporter's output (.ttl or .jsonln) with DCAT-AP specification, the recommended approach is to validate the ttl output against the DCAT-AP SHACL shape [dcat-ap-SHACL.ttl](https://github.com/SEMICeu/DCAT-AP/blob/master/releases/3.0.0/shacl/dcat-ap-SHACL.ttl).
+
+Currently, the compliance testing uses the example output file [src/test/resources/cars/expected/cars.ttl](src/test/resources/cars/expected/cars.ttl), which is validated through the script [src/test/test-output.sh](src/test/test-output.sh), which employs (APACHE Jena shacl application)[https://jena.apache.org/documentation/shacl/].
+
+The objective, for the future, is for this compliance testing to run as an automated Github Action. Ideally the Github Action runner.   

--- a/README.md
+++ b/README.md
@@ -20,8 +20,12 @@ https://guides.dataverse.org/en/latest/installation/config.html#dataverse-spi-ex
 
 ## Exporter Output
 
-In order to test compliance of the exporter's output (.ttl or .jsonln) with DCAT-AP specification, the recommended approach is to validate the ttl output against the DCAT-AP SHACL shape [dcat-ap-SHACL.ttl](https://github.com/SEMICeu/DCAT-AP/blob/master/releases/3.0.0/shacl/dcat-ap-SHACL.ttl).
+In order to test compliance of the exporter's output with the DCAT-AP specification, the recommended approach is to validate exporter's output against the DCAT-AP SHACL shape [dcat-ap-SHACL.ttl](https://github.com/SEMICeu/DCAT-AP/blob/master/releases/3.0.0/shacl/dcat-ap-SHACL.ttl).
 
-Currently, the compliance testing uses the example output file [src/test/resources/cars/expected/cars.ttl](src/test/resources/cars/expected/cars.ttl), which is validated through the script [src/test/test-output.sh](src/test/test-output.sh), which employs (APACHE Jena shacl application)[https://jena.apache.org/documentation/shacl/].
+Compliance testing is performed against example output file [src/test/resources/cars/expected/cars.ttl](src/test/resources/cars/expected/cars.ttl), which is validated through the script [src/test/test-output.sh](src/test/test-output.sh). Testing results are stored in (non-tracked) files:
+* `src/test/resources/cars/validation_output.ttl` containing the full validation report
+* `src/test/resources/cars/shacl-results.csv` containing the validation report
 
-The objective, for the future, is for this compliance testing to run as an automated Github Action. Ideally the Github Action runner.   
+**Requirements**:
+* APACHE Jena [SHACL validator](https://jena.apache.org/documentation/shacl/)
+* APACHE Jena [ARQ SPARQL processor](https://jena.apache.org/documentation/query/)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ https://guides.dataverse.org/en/latest/installation/config.html#dataverse-spi-ex
 
 In order to test compliance of the exporter's output with the DCAT-AP specification, the recommended approach is to validate exporter's output against the DCAT-AP SHACL shape [dcat-ap-SHACL.ttl](https://github.com/SEMICeu/DCAT-AP/blob/master/releases/3.0.0/shacl/dcat-ap-SHACL.ttl).
 
-Compliance testing is performed against example output file [src/test/resources/cars/expected/cars.ttl](src/test/resources/cars/expected/cars.ttl), which is validated through the script [src/test/test-output.sh](src/test/test-output.sh). Testing results are stored in (non-tracked) files:
+Compliance testing is performed against example output file [src/test/resources/cars/expected/cars.ttl](src/test/resources/cars/expected/cars.ttl), which is validated through the script [src/test/test-output.sh](src/test/test-output.sh). 
+
+run: `sh src/test/test-output.sh`
+
+Testing results are stored in (non-tracked) files:
 * `src/test/resources/cars/validation_output.ttl` containing the full validation report
 * `src/test/resources/cars/shacl-results.csv` containing the validation report
 

--- a/src/test/resources/cars/expected/cars.ttl
+++ b/src/test/resources/cars/expected/cars.ttl
@@ -5,9 +5,11 @@ PREFIX foaf:   <http://xmlns.com/foaf/0.1/>
 PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX spdx:   <http://spdx.org/rdf/terms#>
 PREFIX vcard:  <http://www.w3.org/2006/vcard/ns#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#> 
+
 
 <http://localhost:8080/api/access/datafile/4>
-        rdfs:type       dcat:Distribution;
+        a       dcat:Distribution;
         dct:license     <http://creativecommons.org/publicdomain/zero/1.0>;
         dct:rights      <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
         dct:title       "compute.py";
@@ -19,7 +21,7 @@ PREFIX vcard:  <http://www.w3.org/2006/vcard/ns#>
         dcat:mediaType  "http://www.iana.org/assignments/media-types/text/x-python" .
 
 <http://localhost:8080/api/access/datafile/6>
-        rdfs:type       dcat:Distribution;
+        a       dcat:Distribution;
         dct:license     <http://creativecommons.org/publicdomain/zero/1.0>;
         dct:rights      <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
         dct:title       "stata13-auto.tab";
@@ -31,24 +33,24 @@ PREFIX vcard:  <http://www.w3.org/2006/vcard/ns#>
         dcat:mediaType  "http://www.iana.org/assignments/media-types/text/tab-separated-values" .
 
 <https://doi.org/10.5072/FK2/6ZUDGC>
-        rdfs:type          dcat:Dataset;
-        dct:creator        [ rdfs:type                foaf:Person;
-                             vcard:organization-name  "DANS"@en;
+        a          dcat:Dataset;
+        dct:creator        [ a                foaf:Person;
+                             vcard:org  "DANS"@en;
                              foaf:name                "Boon, Paul"@en
                            ];
-        dct:creator        [ rdfs:type                foaf:Person;
-                             vcard:organization-name  "Harvard"@en;
+        dct:creator        [ a                foaf:Person;
+                             vcard:org  "Harvard"@en;
                              foaf:name                "Durbin, Philip"@en
                            ];
         dct:description    "This dataset is about cars."@en;
-        dct:identifier     "https://doi.org/10.5072/FK2/6ZUDGC";
-        dct:issued         "2024-03-20";
+        dct:identifier     <https://doi.org/10.5072/FK2/6ZUDGC>;
+        dct:issued         "2024-03-20"^^xsd:date;
         dct:language       "Danish"@en , "Dutch"@en , "English"@en;
-        dct:modified       "2024-03-20";
+        dct:modified       "2024-03-20"^^xsd:date;
         dct:title          "Cars"@en;
         dcat:contactPoint  [ vcard:fn                 "Durbin, Philip"@en;
                              vcard:hasEmail           "mailto:dataverse@mailinator.com";
-                             vcard:organization-name  "Harvard"@en
+                             vcard:org  "Harvard"@en
                            ];
         dcat:distribution  <http://localhost:8080/api/access/datafile/4> , <http://localhost:8080/api/access/datafile/6> , <http://localhost:8080/api/access/datafile/5>;
         dcat:keyword       "Vehicles"@en , "Transportation"@en , "Automobiles"@en;
@@ -56,7 +58,7 @@ PREFIX vcard:  <http://www.w3.org/2006/vcard/ns#>
         dcat:version       "V1.0" .
 
 <http://localhost:8080/api/access/datafile/5>
-        rdfs:type       dcat:Distribution;
+        a       dcat:Distribution;
         dct:license     <http://creativecommons.org/publicdomain/zero/1.0>;
         dct:rights      <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
         dct:title       "README.md";

--- a/src/test/resources/cars/sparql/all-classes.rq
+++ b/src/test/resources/cars/sparql/all-classes.rq
@@ -1,0 +1,6 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+
+SELECT DISTINCT ?class {
+	?s rdf:type ?class
+}

--- a/src/test/resources/cars/sparql/distributions-in-dataset.rq
+++ b/src/test/resources/cars/sparql/distributions-in-dataset.rq
@@ -1,0 +1,10 @@
+PREFIX dcat: <http://www.w3.org/ns/dcat#>
+PREFIX dct: <http://purl.org/dc/terms/>
+
+SELECT ?dataset ?dist ?dist_class ?dist_title {
+    ?dataset a dcat:Dataset ;
+             dcat:distribution ?dist .
+    ?dist    a ?dist_class ;
+             dct:title ?dist_title 
+
+}

--- a/src/test/resources/cars/sparql/shacl-results.rq
+++ b/src/test/resources/cars/sparql/shacl-results.rq
@@ -1,0 +1,12 @@
+PREFIX sh:     <http://www.w3.org/ns/shacl#>
+
+
+
+SELECT ?result ?focusNode ?msg
+WHERE {
+    ?result a sh:ValidationResult ;
+            sh:resultSeverity sh:Violation;
+            sh:focusNode ?focusNode ;
+            sh:resultMessage ?msg
+
+}

--- a/src/test/test-output.sh
+++ b/src/test/test-output.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# Summary: SHACL validation of example .ttl agains DCAT-AP SHACL shapes
+
+# Requires APACHE Jena shacl application https://jena.apache.org/documentation/shacl/
+
+DATA=./resources/cars/expected/cars.ttl
+SHACLshapes=DCAT-AP/releases/3.0.0/shacl/dcat-ap-SHACL.ttl
+DCATrepo=https://github.com/SEMICeu/DCAT-AP.git 
+DCATbranch=3.0.0
+
+# download DCAT-AP repo to test/DCAT-AP, in order to get the shacl shapes
+if ! [ -d "DCAT-AP" ]; then
+    git clone --depth 1 --branch $DCATbranch $DCATrepo
+fi
+
+
+# validate
+shacl validate --shapes $SHACLshapes --data $DATA
+

--- a/src/test/test-output.sh
+++ b/src/test/test-output.sh
@@ -2,10 +2,14 @@
 
 # Summary: SHACL validation of example .ttl agains DCAT-AP SHACL shapes
 
-# Requires APACHE Jena shacl application https://jena.apache.org/documentation/shacl/
+# Requires APACHE Jena shacl and arq applications https://jena.apache.org/documentation/shacl/ https://jena.apache.org/documentation/query/
 
-DATA=./resources/cars/expected/cars.ttl
+DATA=src/test/resources/cars/expected/cars.ttl
 SHACLshapes=DCAT-AP/releases/3.0.0/shacl/dcat-ap-SHACL.ttl
+SHACLresultsQuery=src/test/resources/cars/sparql/shacl-results.rq
+SHACLresultsSummaryQuery=src/test/resources/cars/validation_output.ttl
+SHACLresultsSummary=src/test/resources/cars/shacl-results.csv
+
 DCATrepo=https://github.com/SEMICeu/DCAT-AP.git 
 DCATbranch=3.0.0
 
@@ -16,5 +20,6 @@ fi
 
 
 # validate
-shacl validate --shapes $SHACLshapes --data $DATA
-
+shacl validate --shapes $SHACLshapes --data $DATA > $SHACLresultsSummaryQuery
+# produce summary
+arq --query $SHACLresultsQuery --data $SHACLresultsSummaryQuery --results=CSV > $SHACLresultsSummary


### PR DESCRIPTION
**What this PR does / why we need it**:

To test compliance of exporter results with the DCAT-AP requirements (defined it its [SHACL shape](https://github.com/SEMICeu/DCAT-AP/blob/master/releases/3.0.0/shacl/dcat-ap-SHACL.ttl))


**Which issue(s) this PR closes**:

- Closes #5 

**Suggestions on how to test this**:
* install the requirements  [SHACL validator](https://jena.apache.org/documentation/shacl/) &  [ARQ SPARQL processor](https://jena.apache.org/documentation/query/)  
* run: `run: `sh src/test/test-output.sh`
* check output of 
* `src/test/resources/cars/validation_output.ttl` & `src/test/resources/cars/shacl-results.csv`

**Is there a release notes update needed for this change?**:


**Additional documentation**:
in README under "Testing" section

